### PR TITLE
Add identifier to map api requests

### DIFF
--- a/src/authoring/components/MapContainer.tsx
+++ b/src/authoring/components/MapContainer.tsx
@@ -8,6 +8,7 @@ import { distance } from "@turf/turf";
 import { remap } from "../../utility/math";
 import { POI } from "../data/POI";
 import { addEmptyGeoJSONSource } from "../../utility/addEmptyGeoJSONSource";
+import { transformRequest } from "../../utility/transformRequest";
 
 export interface Props {
   accessToken: string;
@@ -83,7 +84,8 @@ export class MapContainer extends PureComponent<Props & React.HTMLAttributes<HTM
     if (container !== null && searchContainer !== null) {
       const map = new mapboxgl.Map({
         container,
-        style: "mapbox://styles/mapbox/light-v9"
+        style: "mapbox://styles/mapbox/light-v9",
+        transformRequest
       });
 
       if (onMapCreated) {

--- a/src/display/components/DisplayMapContainer.tsx
+++ b/src/display/components/DisplayMapContainer.tsx
@@ -5,6 +5,7 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import { FeatureCollection, bbox } from "@turf/turf";
 import { BBox2d } from "@turf/helpers/lib/geojson";
 import { DestinationWithProperties } from "../../authoring/data/AuthorState";
+import { transformRequest } from "../../utility/transformRequest";
 
 interface Props {
   accessToken: string;
@@ -79,7 +80,8 @@ export class DisplayMapContainer extends PureComponent<Props & React.HTMLAttribu
     if (container !== null) {
       const map = new mapboxgl.Map({
         container,
-        style: "mapbox://styles/mapbox/light-v9"
+        style: "mapbox://styles/mapbox/light-v9",
+        transformRequest
       });
       this.setupHoverInteraction(map);
       map.on("style.load", () => {

--- a/src/utility/transformRequest.ts
+++ b/src/utility/transformRequest.ts
@@ -1,0 +1,14 @@
+/// Attribute tile requests to this solution.
+/// Passed to the mapboxgl.Map constructor.
+///
+/// This lets us know whether people are finding this source code useful,
+/// and influences our decision of whether to open-source more code in the future.
+/// Please keep it in your project if you find this starter code helpful
+/// so we can continue to make and share sample projects.
+export const transformRequest = (url: string): { url: string } => {
+  const hasQuery = url.indexOf("?") !== -1;
+  const suffix = hasQuery ? "&pluginName=consumer_workflow" : "?pluginName=consumer_workflow";
+  return {
+    url: url + suffix
+  };
+};


### PR DESCRIPTION
## What Changed
Use the `transformRequest` parameter to add some way to keep track of usage. Encourage others to keep it there when they build things.

## Open Questions
Is the `pluginName` parameter a meaningful name, or could I use any name I wanted? I copied the parameter name from the FramerX plugin, since I'm going for consistency across solutions to make analytics easier. Should we consider snake_case for `plugin_name`, since we use that for other API parameters?

Is `consumer_workflow` a good name to pass as a parameter for tracking? Should we try to make it shorter (at the expense of legibility)?